### PR TITLE
Bump to 1.0.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <packaging>jar</packaging>
     <groupId>org.webjars</groupId>
     <artifactId>jquery-chained</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.0-SNAPSHOT</version>
     <name>Chained</name>
     <description>WebJar for Chained</description>
     <url>http://webjars.org</url>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <packaging>jar</packaging>
     <groupId>org.webjars</groupId>
     <artifactId>jquery-chained</artifactId>
-    <version>0.9.3-2-SNAPSHOT</version>
+    <version>1.0.0</version>
     <name>Chained</name>
     <description>WebJar for Chained</description>
     <url>http://webjars.org</url>
@@ -43,13 +43,13 @@
         <dependency>
             <groupId>org.webjars</groupId>
             <artifactId>jquery</artifactId>
-            <version>1.9.1</version>
+            <version>1.10.2</version>
         </dependency>
     </dependencies>
     
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <upstream.version>0.9.3</upstream.version>
+        <upstream.version>1.0.0</upstream.version>
         <upstream.url>https://raw.github.com/tuupola/jquery_chained/${upstream.version}</upstream.url>
         <destDir>${project.build.outputDirectory}/META-INF/resources/webjars/${project.artifactId}/${upstream.version}</destDir>
     </properties>


### PR DESCRIPTION
Update jquery_chained to version 1.0.0.
Updated jquery webjar as well to version used in the official examples.
